### PR TITLE
Add smarter session managing for HTTP requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 venv/
 
 content/bot_data\.json
+content/cookies.pkl
 
 *.log


### PR DESCRIPTION
Aggiunto user agent personalizzato e gestione di cookie con cache su file per emulare il comportamento di un browser ed evitare eventuali ban/limiti da siti a cui potrebbe non piacere ricevere richieste HTTP "strane".

N.B.: Non ho fatto girare il codice anche se mi sembra non vi siano errori, testare personalmente prima di un eventuale merge.