### PR TITLE
Titolo: "telegram" -> "tg"

### DIFF
--- a/content/bot_data_examples.json
+++ b/content/bot_data_examples.json
@@ -10,6 +10,6 @@
     "user_agent": "",
     "username": "",
     "password": "",
-    "title_prefix": "Telegram - "
+    "title_prefix": "TG - "
   }
 }


### PR DESCRIPTION
Occupava troppo spazio nel titolo di reddit iniziare con [Telegram - @ArmeF97] Titolo vero...