### PR TITLE
Add support for @admin

### DIFF
--- a/marvin.py
+++ b/marvin.py
@@ -713,7 +713,9 @@ class MarvinBot:
                 self.admin(update)
             else:
                 self.delete_message_if_admin(update.message.chat, update.message.message_id, 5)
-        return
+
+        elif update.message.text is not None and "@admin" in update.message.text:
+            self.admin(update)
 
     def main(self):
         """Start the bot."""


### PR DESCRIPTION
Most of the other bots uses @admin instead of /admin to trigger admins
so add support for it too.

It only works when the bot is admin of the group.
If the bot is not an admin it must have the Privacy Mode disabled (in
BotFather).